### PR TITLE
Troca o nome da action update para reject

### DIFF
--- a/app/controllers/job_profiles_controller.rb
+++ b/app/controllers/job_profiles_controller.rb
@@ -2,7 +2,7 @@
 
 class JobProfilesController < ApplicationController
   before_action :authenticate_user!, only: [ :create ]
-  before_action :authenticate_headhunter!, only: [ :index, :edit, :update ]
+  before_action :authenticate_headhunter!, only: [ :index, :edit, :reject ]
   def create
     @job_opportunity = JobOpportunity.find(params[:job_opportunity_id])
     @job_profile = JobProfile.new
@@ -23,9 +23,9 @@ class JobProfilesController < ApplicationController
     @job_profile = JobProfile.find(params[:id])
   end
 
-  def update
+  def reject
     @job_opportunity = JobOpportunity.find(params[:job_opportunity_id])
-    @job_profile = JobProfile.find(params[:id])
+    @job_profile = JobProfile.find(params[:job_profile_id])
     if @job_profile.update(params.require(:job_profile).permit(:feedback).merge(rejected: true))
       redirect_to @job_profile.profile
     else

--- a/app/views/job_profiles/edit.html.erb
+++ b/app/views/job_profiles/edit.html.erb
@@ -2,7 +2,7 @@
 
 <%= render 'share/errors', object: @job_profile %>
 
-<%= form_with model: [@job_opportunity, @job_profile], local: true do |f| %>
+<%= form_with model: @job_profile, url: job_opportunity_job_profile_reject_path(@job_opportunity, @job_profile), local: true do |f| %>
   <%= f.label :feedback %>
   <%= f.text_field :feedback %>
   <%= f.submit 'Enviar' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root 'home#index'
   resources :job_opportunities do
-    resources :job_profiles, only: [:new, :create, :index, :edit, :update]
+    resources :job_profiles, only: [:new, :create, :index, :edit] do
+      patch :reject
+    end
     resources :offers, only: [:new, :create] do
       put '/accept', to: 'offers#accept'
       get '/reject', to: 'offers#review'

--- a/spec/request/job_profile_authorization_spec.rb
+++ b/spec/request/job_profile_authorization_spec.rb
@@ -22,7 +22,7 @@ describe 'job profile', type: :request do
     it 'cannot update' do
       job_opportunity = create(:job_opportunity)
       job_profile = create(:job_profile)
-      put job_opportunity_job_profile_path(job_opportunity, job_profile), params: {}
+      patch job_opportunity_job_profile_reject_path(job_opportunity, job_profile), params: {}
 
       expect(response).to redirect_to(new_headhunter_session_path)
     end
@@ -32,7 +32,7 @@ describe 'job profile', type: :request do
       login_as user, scope: :user
       job_opportunity = create(:job_opportunity)
       job_profile = create(:job_profile)
-      put job_opportunity_job_profile_path(job_opportunity, job_profile), params: {}
+      patch job_opportunity_job_profile_reject_path(job_opportunity, job_profile), params: {}
 
       expect(response).to redirect_to(new_headhunter_session_path)
     end


### PR DESCRIPTION
### **Motivação** 
---
A action usada para rejeitar um candidato em uma vaga era update, porém action simplesmente rejeita e não muda nenhum outro dado do candidato, deixando o código um pouco menos legível.

### **Solução proposta**
---
Mudar o nome da action de update para reject deixando mais específico a função da action, e criar uma rota customizada para essa action.

### **Comentários** 
---
A lógica continuo a mesma, simplesmente deixando o código mais legível.